### PR TITLE
TT-855: Change to use 'ssoLocation' and require 'levelOfAssurance'

### DIFF
--- a/lib/passport-verify-strategy.ts
+++ b/lib/passport-verify-strategy.ts
@@ -10,7 +10,7 @@ import { default as VerifyServiceProviderClient, Logger } from './verify-service
 export interface AuthnRequestResponse {
   samlRequest: string,
   requestId: string,
-  location: string
+  ssoLocation: string
 }
 
 export interface Address {
@@ -134,7 +134,7 @@ export class PassportVerifyStrategy extends Strategy {
       const authnRequestResponseBody = authnRequestResponse.body as AuthnRequestResponse
       this.saveRequestId(authnRequestResponseBody.requestId, request)
       const response = (request as any).res
-      return response.send(createSamlForm(authnRequestResponseBody.location, authnRequestResponseBody.samlRequest))
+      return response.send(createSamlForm(authnRequestResponseBody.ssoLocation, authnRequestResponseBody.samlRequest))
     } else {
       const errorBody = authnRequestResponse.body as ErrorBody
       throw new Error(errorBody.reason)

--- a/lib/verify-service-provider-client.ts
+++ b/lib/verify-service-provider-client.ts
@@ -38,7 +38,9 @@ export default class VerifyServiceProviderClient {
   }
 
   generateAuthnRequest () {
-    return this._request('POST', this.verifyServiceProviderHost + '/generate-request')
+    return this._request('POST', this.verifyServiceProviderHost + '/generate-request',
+    { 'Content-Type': 'application/json' },
+        `{ "levelOfAssurance": "LEVEL_2" }`)
   }
 
   translateResponse (samlResponse: string, requestId: string) {

--- a/test/passport-verify-strategy-test.ts
+++ b/test/passport-verify-strategy-test.ts
@@ -19,7 +19,7 @@ describe('The passport-verify strategy', function () {
     body: {
       samlRequest: 'some-saml-req',
       requestId: 'some-request-id',
-      location: 'http://hub-sso-uri'
+      ssoLocation: 'http://hub-sso-uri'
     }
   }
 

--- a/test/verify-service-provider-client-test.ts
+++ b/test/verify-service-provider-client-test.ts
@@ -10,7 +10,7 @@ describe('The passport-verify client', function () {
   const exampleAuthnRequest = {
     samlRequest: 'some-saml-req',
     requestId: 'some-request-id',
-    location: 'http://hub-sso-uri'
+    ssoLocation: 'http://hub-sso-uri'
   }
 
   const exampleTranslatedResponse = {
@@ -117,8 +117,8 @@ describe('The passport-verify client', function () {
 
     return client.generateAuthnRequest()
       .then(response => {
-        td.verify(testLogger.info('passport-verify', 'POST', 'http://localhost:3003/generate-request', ''))
-        td.verify(testLogger.info('passport-verify', '200 OK', '{\"samlRequest\":\"some-saml-req\",\"requestId\":\"some-request-id\",\"location\":\"http://hub-sso-uri\"}'))
+        td.verify(testLogger.info('passport-verify', 'POST', 'http://localhost:3003/generate-request', '{ \"levelOfAssurance\": \"LEVEL_2\" }'))
+        td.verify(testLogger.info('passport-verify', '200 OK', '{\"samlRequest\":\"some-saml-req\",\"requestId\":\"some-request-id\",\"ssoLocation\":\"http://hub-sso-uri\"}'))
       })
   })
 


### PR DESCRIPTION
VSP requires a levelOfAssurance at generate-request endpoint.
Endpoint response returns 'ssoLocation' instead of 'location' now

Authors: @andy-paine @tunylund