### PR TITLE
TT-1140 - Update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,5 +190,10 @@ npm install
 
 __Compile and test the code__
 ```
-./pre-commit.sh
+npm test
+```
+
+__Install dependencies, compile and test the code - run this before commiting__
+```
+npm run pre-commit
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,17 @@
 {
   "name": "passport-verify",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "dependencies": {
     "@types/debug": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
       "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
+    },
+    "@types/escape-html": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-0.0.20.tgz",
+      "integrity": "sha512-6dhZJLbA7aOwkYB2GDGdIqJ20wmHnkDzaxV9PJXe7O02I2dSFTERzRB6JrX6cWKaS+VqhhY7cQUMCbO5kloFUw=="
     },
     "@types/express": {
       "version": "4.0.36",
@@ -336,6 +341,11 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -390,12 +400,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
     "graceful-readlink": {
@@ -542,12 +546,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
-    "jsonfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
       "dev": true
     },
     "jsonify": {
@@ -995,12 +993,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
-    },
-    "universalify": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.0.tgz",
-      "integrity": "sha1-nrHEZR3rzGcMyU8adXYjMruWd3g=",
-      "dev": true
     },
     "uuid": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "npm run build && mocha ./build/test/* && npm run lint",
     "build": "tsc -d",
     "lint": "tslint -c tslint.json -p .",
+    "pre-commit": "npm install && npm test",
     "docs": "mv {,.}test && typedoc --readme none --out docs --excludePrivate && touch docs/.nojekyll; mv {.,}test"
   },
   "author": {

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,10 +1,2 @@
 #!/usr/bin/env bash
-set -e
-CURRENT_DIR=$PWD
-function cleanup {
-  cd "$CURRENT_DIR"
-}
-trap cleanup EXIT
-cd "$(dirname "$0")"
-npm install
-npm test
+npm run pre-commit


### PR DESCRIPTION
Less to do in this one - this just moves the 'work' from the pre-commit shell script (which again still exists but just calls a single npm script) to the pre-commit npm script.

It also updates package-lock, because various things were breaking because of not being able to find the correct modules until I let it regenerate itself.