### PR TITLE
bau: Remove TypeScript syntax from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Usage
     // The requestID should be saved in a secure manner, and such that it
     // corresponds to the user's current session and can be retrieved in order to validate
     // that SAML response that is returned from the IDP corresponds to the original AuthnRequest.
-    function saveRequestId (requestId: string, request: any) {
+    function saveRequestId (requestId, request) {
 
       // The following is an example that saves the requestId using the express-session middleware
       // This would require express-session to be initialised with a secure secret e.g:
@@ -109,7 +109,7 @@ Usage
     // A callback that returns the requestId that corresponds to the user's session.
     // This is used by the Verify Service Provider to ensure SAMLResponses received from IDPS
     // correspond to a the user's active session.
-    function loadRequestId (request: any) {
+    function loadRequestId (request) {
 
       // The following is an example that retrieves the request ID from the aforementioned 
       // express-session object.


### PR DESCRIPTION
Authors: @richardtowers