### PR TITLE
Pass in form styling - DO NOT MERGE YET

### DIFF
--- a/lib/saml-form.ts
+++ b/lib/saml-form.ts
@@ -19,18 +19,5 @@ export function createSamlForm (ssoLocation: string, samlRequest: string) {
       window.setTimeout(function () { form.removeAttribute('style') }, 5000)
       form.submit()
     </script>
-    <style type='text/css'>
-      .passport-verify-saml-form {
-        font-family: Arial, sans-serif;
-      }
-      .passport-verify-button {
-        background-color: #00692f;
-        color: #fff;
-        padding: 10px;
-        font-size: 1em;
-        border: none;
-        box-shadow: 0 2px 0 #003618;
-      }
-    </style>
   `
 }


### PR DESCRIPTION
This extension to the TT-1143 pull request would add the ability to pass in a wrapper function for the saml form, so that the relying party can add their own stylesheet/headers/footers etc. This seems good, because this page is still on their domain so it makes sense that they can make it match their styling. (Done in this form in order to have minimal changes to the api). But it feels like it has more potential for mistakes.

See [stub relying party pull request](https://github.com/alphagov/passport-verify-stub-relying-party/pull/11)

Opinions desired...