### PR TITLE
TT-1285 Add ability to specify entityId to use for requests to the VSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,18 @@ Usage
       // The following is an example that retrieves the request ID from the aforementioned 
       // express-session object.
       return request.session.requestId
-    }
+    },
+    // Service Entity Id
+    'http://your-service-entity-id'
+    // This is only required when your Verify Service Provider is set up to be multi tenanted.
+    // If it is provided, it is passed to the Verify Service Provider with each request, and
+    // used to identify this service.
    ))
    ```
 
 1. Configure routes for the authentication flow
 
-   See [createResponseHandler](https://alphagov.github.io/passport-verify/modules/_create_response_handler_.html#createresponsehandler) 
+   See [createResponseHandler](https://alphagov.github.io/passport-verify/modules/_create_response_handler_.html#createresponsehandler)
    and its [callbacks](https://alphagov.github.io/passport-verify/interfaces/_create_response_handler_.responsescenarios.html#onauthnfailed) in the API documentation.
 
    ```javascript

--- a/lib/verify-service-provider-client.ts
+++ b/lib/verify-service-provider-client.ts
@@ -17,9 +17,14 @@ export default class VerifyServiceProviderClient {
 
   constructor (private verifyServiceProviderHost: string) {}
 
-  async generateAuthnRequest (): Promise<{ status: number, body: AuthnRequestResponse | ErrorMessage }> {
+  async generateAuthnRequest (entityId?: string): Promise<{ status: number, body: AuthnRequestResponse | ErrorMessage }> {
     try {
-      const responseBody = await this.sendRequest<AuthnRequestResponse>('/generate-request', { levelOfAssurance: 'LEVEL_2' })
+      let requestBody: any = { levelOfAssurance: 'LEVEL_2' }
+      if (entityId) {
+        requestBody.entityId = entityId
+      }
+
+      const responseBody = await this.sendRequest<AuthnRequestResponse>('/generate-request', requestBody)
       this.infoLog('authn request generated, request id: ', responseBody.requestId)
       return {
         status: 200,
@@ -34,9 +39,14 @@ export default class VerifyServiceProviderClient {
     }
   }
 
-  async translateResponse (samlResponse: string, requestId: string): Promise<{ status: number, body: TranslatedResponseBody | ErrorMessage }> {
+  async translateResponse (samlResponse: string, requestId: string, entityId?: string): Promise<{ status: number, body: TranslatedResponseBody | ErrorMessage }> {
     try {
-      const responseBody = await this.sendRequest<TranslatedResponseBody>('/translate-response', { samlResponse, requestId, levelOfAssurance: 'LEVEL_2' })
+      let requestBody: any = { samlResponse, requestId, levelOfAssurance: 'LEVEL_2' }
+      if (entityId) {
+        requestBody.entityId = entityId
+      }
+
+      const responseBody = await this.sendRequest<TranslatedResponseBody>('/translate-response', requestBody)
       this.infoLog('response translated for request: ', requestId, 'Scenario: ', responseBody.scenario)
       return {
         status: 200,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-verify",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A passport.js strategy for authenticating with Verify and Verify Service Provider",
   "repository": "https://github.com/alphagov/passport-verify",
   "bugs": "https://github.com/alphagov/passport-verify/issues",

--- a/test/verify-service-provider-client-test.ts
+++ b/test/verify-service-provider-client-test.ts
@@ -79,7 +79,7 @@ describe('The passport-verify client', function () {
     mockVerifyServiceProvider.close(done)
   })
 
-  it('should generate authnRequest', function () {
+  it('should generate authnRequest when not passed an entityId', function () {
     const client = new VerifyServiceProviderClient(mockVerifyServiceProviderUrl)
 
     return client.generateAuthnRequest()
@@ -89,10 +89,32 @@ describe('The passport-verify client', function () {
       })
   })
 
-  it('should translate response body', function () {
+  it('should generate authnRequest when passed an entityId', function () {
+    const client = new VerifyServiceProviderClient(mockVerifyServiceProviderUrl)
+    const entityId = 'http://service-entity-id'
+
+    return client.generateAuthnRequest(entityId)
+      .then(response => {
+        assert.equal(response.status, 200)
+        assert.deepEqual(response.body, exampleAuthnRequest)
+      })
+  })
+
+  it('should translate response body when not passed an entityId', function () {
     const client = new VerifyServiceProviderClient(mockVerifyServiceProviderUrl)
 
     return client.translateResponse(SUCCESS_SCENARIO, 'some-request-id')
+      .then(response => {
+        assert.equal(response.status, 200)
+        assert.deepEqual(response.body, exampleTranslatedResponse)
+      })
+  })
+
+  it('should translate response body when passed an entityId', function () {
+    const client = new VerifyServiceProviderClient(mockVerifyServiceProviderUrl)
+    const entityId = 'http://service-entity-id'
+
+    return client.translateResponse(SUCCESS_SCENARIO, 'some-request-id', entityId)
       .then(response => {
         assert.equal(response.status, 200)
         assert.deepEqual(response.body, exampleTranslatedResponse)
@@ -115,14 +137,14 @@ describe('The passport-verify client', function () {
     const testLogger = td.function() as (message?: any, ...optionalParams: any[]) => void
     client.requestLog = testLogger as any
 
-    return client.generateAuthnRequest()
+    return client.generateAuthnRequest('http://service-entity-id')
       .then(response => {
         td.verify(testLogger(
           'sending request: ',
           'POST',
           'http://localhost:3003/generate-request',
           { 'Content-Type': 'application/json' },
-          { levelOfAssurance: 'LEVEL_2' }
+          { entityId: 'http://service-entity-id', levelOfAssurance: 'LEVEL_2' }
         ))
       })
   })


### PR DESCRIPTION
Allows passport-verify to be used with a multi tenanted Verify Service Provider

Authors: @rachaelbooth