### PR TITLE
bau: Hide / show SAML form in pure JS

### DIFF
--- a/lib/saml-form.ts
+++ b/lib/saml-form.ts
@@ -15,8 +15,8 @@ export function createSamlForm (ssoLocation: string, samlRequest: string) {
     </form>
     <script>
       var form = document.forms[0]
-      form.setAttribute('style', 'display: none;')
-      window.setTimeout(function () { form.removeAttribute('style') }, 5000)
+      form.style.display = 'none'
+      window.setTimeout(function () { form.style.display = 'block' }, 5000)
       form.submit()
     </script>
     <style type='text/css'>


### PR DESCRIPTION
This works around an issue where the user's web server sets a
Content-Security-Policy header which has allows inline JS, but
not inline CSS.

Prior to this commit the form would not be hidden as the JS attempts to
add an inline style, which is disabled by the CSP. By setting the
display property directly in JS we don't need to depend on CSS being
enabled.

I've tested this locally by `yarn link`ing this into
`passport-verify-stub-relying-party` and it still works. Once we've
published a new version to npm we'll need to bump the version in PVSRP.