### PR TITLE
Add matrix of node versions to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
   - "6.14.1" # Current version on PaaS
-  - "6.14.2" # Latest 6.x release
-  - "8.11.2" # LTS release
-  - "10.3.0" # Current release
+  - "lts/*"  # LTS release
+  - "node"   # Current release
 cache:
   directories:
     - "node_modules"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6.11.0" # Current version on PaaS
+  - "6.14.1" # Current version on PaaS
   - "6.14.2" # Latest 6.x release
   - "8.11.2" # LTS release
   - "10.3.0" # Current release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: node_js
+node_js:
+  - "6.11.0" # Current version on PaaS
+  - "6.14.2" # Latest 6.x release
+  - "8.11.2" # LTS release
+  - "10.3.0" # Current release
 cache:
   directories:
     - "node_modules"


### PR DESCRIPTION
This should give us confidence that passport-verify works with later versions
of nodejs.