### PR TITLE
bau: Allow Level of Assurance 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ Usage
     // This is only required when your Verify Service Provider is set up to be multi tenanted.
     // If it is provided, it is passed to the Verify Service Provider with each request, and
     // used to identify this service.
-    ,
+
     // Saml Form Template Location
-    'saml-form-template.njk'
+    'saml-form-template.njk',
     // This is an optional parameter which can be used to style the saml form
     // used to send the authn request to Verify.
     // This template should only be rendered if Javascript has been disabled in the user's browser.
@@ -124,6 +124,10 @@ Usage
     // will be provided to the named template for rendering.
     // If this is not provided, passport-verify will render a default auto posting form
     // with the correct attributes.
+
+    // Level of Assurance
+    // LEVEL_1 or LEVEL2 depending on your service's requirements. Defaults to LEVEL_2.
+    'LEVEL_2'
    ))
    ```
 

--- a/lib/verify-service-provider-client.ts
+++ b/lib/verify-service-provider-client.ts
@@ -17,9 +17,9 @@ export default class VerifyServiceProviderClient {
 
   constructor (private verifyServiceProviderHost: string) {}
 
-  async generateAuthnRequest (entityId?: string): Promise<{ status: number, body: AuthnRequestResponse | ErrorMessage }> {
+  async generateAuthnRequest (levelOfAssurance: ('LEVEL_1' | 'LEVEL_2'), entityId?: string): Promise<{ status: number, body: AuthnRequestResponse | ErrorMessage }> {
     try {
-      let requestBody: any = { levelOfAssurance: 'LEVEL_2' }
+      let requestBody: any = { levelOfAssurance }
       if (entityId) {
         requestBody.entityId = entityId
       }
@@ -39,9 +39,9 @@ export default class VerifyServiceProviderClient {
     }
   }
 
-  async translateResponse (samlResponse: string, requestId: string, entityId?: string): Promise<{ status: number, body: TranslatedResponseBody | ErrorMessage }> {
+  async translateResponse (samlResponse: string, requestId: string, levelOfAssurance: ('LEVEL_1' | 'LEVEL_2'), entityId?: string): Promise<{ status: number, body: TranslatedResponseBody | ErrorMessage }> {
     try {
-      let requestBody: any = { samlResponse, requestId, levelOfAssurance: 'LEVEL_2' }
+      let requestBody: any = { samlResponse, requestId, levelOfAssurance: levelOfAssurance }
       if (entityId) {
         requestBody.entityId = entityId
       }

--- a/test/verify-service-provider-client-test.ts
+++ b/test/verify-service-provider-client-test.ts
@@ -82,7 +82,7 @@ describe('The passport-verify client', function () {
   it('should generate authnRequest when not passed an entityId', function () {
     const client = new VerifyServiceProviderClient(mockVerifyServiceProviderUrl)
 
-    return client.generateAuthnRequest()
+    return client.generateAuthnRequest('LEVEL_2')
       .then(response => {
         assert.equal(response.status, 200)
         assert.deepEqual(response.body, exampleAuthnRequest)
@@ -93,7 +93,7 @@ describe('The passport-verify client', function () {
     const client = new VerifyServiceProviderClient(mockVerifyServiceProviderUrl)
     const entityId = 'http://service-entity-id'
 
-    return client.generateAuthnRequest(entityId)
+    return client.generateAuthnRequest('LEVEL_2', entityId)
       .then(response => {
         assert.equal(response.status, 200)
         assert.deepEqual(response.body, exampleAuthnRequest)
@@ -103,7 +103,7 @@ describe('The passport-verify client', function () {
   it('should translate response body when not passed an entityId', function () {
     const client = new VerifyServiceProviderClient(mockVerifyServiceProviderUrl)
 
-    return client.translateResponse(SUCCESS_SCENARIO, 'some-request-id')
+    return client.translateResponse(SUCCESS_SCENARIO, 'some-request-id', 'LEVEL_2')
       .then(response => {
         assert.equal(response.status, 200)
         assert.deepEqual(response.body, exampleTranslatedResponse)
@@ -114,7 +114,7 @@ describe('The passport-verify client', function () {
     const client = new VerifyServiceProviderClient(mockVerifyServiceProviderUrl)
     const entityId = 'http://service-entity-id'
 
-    return client.translateResponse(SUCCESS_SCENARIO, 'some-request-id', entityId)
+    return client.translateResponse(SUCCESS_SCENARIO, 'some-request-id', 'LEVEL_2', entityId)
       .then(response => {
         assert.equal(response.status, 200)
         assert.deepEqual(response.body, exampleTranslatedResponse)
@@ -124,7 +124,7 @@ describe('The passport-verify client', function () {
   it('should resolve error responses', function () {
     const client = new VerifyServiceProviderClient(mockVerifyServiceProviderUrl)
 
-    return client.translateResponse(ERROR_SCENARIO, 'some-request-id')
+    return client.translateResponse(ERROR_SCENARIO, 'some-request-id', 'LEVEL_2')
       .then(response => {
         assert.equal(response.status, 422)
         assert.deepEqual(response.body, exampleErrorResponse)
@@ -137,7 +137,7 @@ describe('The passport-verify client', function () {
     const testLogger = td.function() as (message?: any, ...optionalParams: any[]) => void
     client.requestLog = testLogger as any
 
-    return client.generateAuthnRequest('http://service-entity-id')
+    return client.generateAuthnRequest('LEVEL_2', 'http://service-entity-id')
       .then(response => {
         td.verify(testLogger(
           'sending request: ',
@@ -155,7 +155,7 @@ describe('The passport-verify client', function () {
     const testLogger = td.function() as (message?: any, ...optionalParams: any[]) => void
     client.infoLog = testLogger as any
 
-    return client.generateAuthnRequest()
+    return client.generateAuthnRequest('LEVEL_2')
       .then(response => {
         td.verify(testLogger('authn request generated, request id: ', 'some-request-id'))
       })
@@ -188,7 +188,7 @@ describe('The passport-verify client', function () {
       const testLogger = td.function() as (message?: any, ...optionalParams: any[]) => void
       client.infoLog = testLogger as any
 
-      return client.generateAuthnRequest()
+      return client.generateAuthnRequest('LEVEL_2')
         .then(response => {
           td.verify(testLogger(
             'error generating authn request: ',
@@ -205,7 +205,7 @@ describe('The passport-verify client', function () {
     const testLogger = td.function() as (message?: any, ...optionalParams: any[]) => void
     client.requestLog = testLogger as any
 
-    return client.translateResponse(SUCCESS_SCENARIO, 'some-request-id')
+    return client.translateResponse(SUCCESS_SCENARIO, 'some-request-id', 'LEVEL_2')
       .then(response => {
         td.verify(testLogger(
           'sending request: ',
@@ -223,7 +223,7 @@ describe('The passport-verify client', function () {
     const testLogger = td.function() as (message?: any, ...optionalParams: any[]) => void
     client.infoLog = testLogger as any
 
-    return client.translateResponse(SUCCESS_SCENARIO, 'some-request-id')
+    return client.translateResponse(SUCCESS_SCENARIO, 'some-request-id', 'LEVEL_2')
       .then(response => {
         td.verify(testLogger('response translated for request: ', 'some-request-id', 'Scenario: ', 'SUCCESS'))
       })
@@ -235,7 +235,7 @@ describe('The passport-verify client', function () {
     const testLogger = td.function() as (message?: any, ...optionalParams: any[]) => void
     client.infoLog = testLogger as any
 
-    return client.translateResponse(ERROR_SCENARIO, 'some-request-id')
+    return client.translateResponse(ERROR_SCENARIO, 'some-request-id', 'LEVEL_2')
       .then(response => {
         td.verify(testLogger(
           'error translating response for request id: ',


### PR DESCRIPTION
Previously passport-verify hardcoded the Level of Assurance to LEVEL_2,
so even though the VSP is capable of supporting both levels services
weren't able to use this for LEVEL_1 without forking passport-verify.

There are two situations where the levelOfAssurance parameter is needed:
* The generateAuthnRequest call (optional - not used by the current
  version of the VSP / Verify)
* The translateResponse call (required - specifies the minimum allowed
  level)

This commit allows the user to specify the level of assurance when they
initialise the strategy and passes the value through to both API calls.

The docs have been updated accordingly.

Fixes #42.