### PR TITLE
JKqS74p1: Update TypeDoc to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1362,8 +1362,8 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "typedoc": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.11.1.tgz",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.12.0.tgz",
       "integrity": "sha1-nwM4h/0iGMdp4QRf64ih7+2fEsk=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "testdouble": "^3.3.1",
     "tslint": "5.10.0",
     "tslint-config-standard": "^8.0.1",
-    "typedoc": "0.11.1",
+    "typedoc": "0.12.0",
     "typescript": "^2.4.2"
   },
   "files": [


### PR DESCRIPTION
Doing this in preparation for a release.
There was a GreenKeeper PR for this but it got messed up.

https://trello.com/c/JKqS74p1/85-release-a-new-version-of-passport-verify

Solo: @alan-gds