### PR TITLE
BAU: Update PUBLISHING TO NPM readme

### DIFF
--- a/PUBLISHING_TO_NPM.md
+++ b/PUBLISHING_TO_NPM.md
@@ -1,4 +1,4 @@
-## Passport Verify Stub Relying Party - Publishing the package to NPM
+## Passport Verify - Publishing the package to NPM
 
 Any updates to the package, including incrementing the versions of dependencies as recommended by Greenkeeper
 should be published to NPM using
@@ -15,7 +15,7 @@ In order to publish this package, the developer needs to create an account with 
 npm adduser
 ```
 
-This account should then be added to the @verify organisation by an admin.
+This account should then be added to the @verify organisation by an org owner.
 This will automatically add that user to the 'developers' team and give that account read and write access
 to the passport-verify package.
 
@@ -23,8 +23,10 @@ to the passport-verify package.
 
 If a member of this developers team leaves, they should be removed from the @verify organisation's membership list.
 
-This can be done by an admin through the npm portal
+This can be done by an org owner through the npm portal
 
-a list of members can be seen using:
+A list of members can be seen using:
 
-```npm team ls verify:developers```
+```
+npm team ls verify:developers
+```


### PR DESCRIPTION
to clarify adding users to an npm org must be done by an org owner and not admin