### PR TITLE
TyGN7itP: Update attributes

### DIFF
--- a/lib/verify-service-provider-api/translated-response-body.ts
+++ b/lib/verify-service-provider-api/translated-response-body.ts
@@ -101,10 +101,10 @@ export interface Address {
  */
 
 export interface IdentityAttributes {
-  firstName?: VerifiableIdentityAttribute<String>,
+  firstNames?: VerifiableIdentityAttribute<String>[],
   middleNames?: VerifiableIdentityAttribute<String>[],
   surnames?: VerifiableIdentityAttribute<String>[],
-  dateOfBirth?: VerifiableIdentityAttribute<String>,
+  datesOfBirth?: VerifiableIdentityAttribute<String>[],
   gender?: String,
   addresses?: VerifiableIdentityAttribute<IdentityAddress>[]
 }
@@ -117,4 +117,5 @@ export interface IdentityAddress {
   lines?: string[],
   postCode?: string,
   internationalPostCode?: string,
+  uprn?: string
 }


### PR DESCRIPTION
We've changed most of the non-matching attributes returned by VSP
from strings to lists. This is to reflect that. It also uncovered
a missed bit when handling the identity (since the attributes were not
matching the matching ones)